### PR TITLE
BUG: zero like count when unlike

### DIFF
--- a/src/components/Posts/SinglePost.jsx
+++ b/src/components/Posts/SinglePost.jsx
@@ -60,7 +60,10 @@ export function SinglePost({ article, id }) {
     try {
       if (hasLiked) {
         setHasLiked(false);
-        setLikes((likes) => likes.filter((like) => like === user.id));
+        const updatedLikes = likes.slice();
+        const index = updatedLikes.indexOf(user.id);
+        updatedLikes.splice(index, 1);
+        setLikes(updatedLikes);
         const articleRef = db.collection("articles").doc(id);
         await articleRef.update({
           likedBy: firebase.firestore.FieldValue.arrayRemove(user.uid),


### PR DESCRIPTION
Follow this checklist for submitting a pull request (PR):

- [x] Your branch is up-to-date with the main branch.
- [x] You are submitting your PR against the main branch of the repository you are contributing to from your fork.

#204 

This resolves the bug, when there is a liked post and the user like it the like count changes, but when dislikes the like count goes to 0, this was happening because of the **filter** function, resolve it using the **splice** method