### PR TITLE
Fixes #285 keeping drawer open from landscape tablets onwards

### DIFF
--- a/src/components/Login/stylesLoginPage.jsx
+++ b/src/components/Login/stylesLoginPage.jsx
@@ -34,8 +34,9 @@ const Container = styled.div`
     row-gap: 1rem;
 
     &:not(.open) {
-      padding-left: 255px;
+      padding-left: 2rem;
     }
+
     &.open {
       padding-left: 2rem;
     }
@@ -68,6 +69,10 @@ const Nav = styled.nav`
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   border: 1px solid #ffffff2d;
+
+  @media (min-width: 768px) and (orientation: landscape) {
+    position: static;
+  }
 
   top: 0;
   left: 0;


### PR DESCRIPTION
Follow this checklist for submitting a pull request (PR):

- [x] Your branch is up-to-date with the main branch.
- [x] You are submitting your PR against the main branch of the repository you are contributing to from your fork.
- [x] You have linked your GitHub issue at the **Resolves Issue** section if it exists.
- [x] You have provided a brief description of the issue.


## Description
The drawer (nav) is fixed such that it will always be open from tablet mode in horizontal view.

**Resolves Issue**: closes #285 
### Desktop
<img width="1440" alt="Screenshot 2023-01-25 at 11 07 04 PM" src="https://user-images.githubusercontent.com/97731239/214642624-03dc426e-221d-4b84-b860-218e6b39f9f0.png">

### Tablet landscape
<img width="1440" alt="Screenshot 2023-01-25 at 11 07 19 PM" src="https://user-images.githubusercontent.com/97731239/214642667-fd6c3d43-fff7-4de7-960d-5c5f45b59e43.png">

### Tablet potrait
<img width="1440" alt="Screenshot 2023-01-25 at 11 07 15 PM" src="https://user-images.githubusercontent.com/97731239/214642641-e0291b55-cd5f-4ad7-8e65-3cad34d90466.png">

### Mobile
<img width="1440" alt="Screenshot 2023-01-25 at 11 07 32 PM" src="https://user-images.githubusercontent.com/97731239/214642687-001f0e40-20a7-4224-90c5-0fba10d04560.png">


