### PR TITLE
React Hook useEffect has a missing dependency

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,10 +26,10 @@ const Resources = lazy(() =>
 );
 const AboutUs = lazy(() => import("./components/AboutUs/AboutUs"));
 
-function App(props) {
+function App({ getUserAuth }) {
   useEffect(() => {
-    props.getUserAuth();
-  }, []);
+    getUserAuth();
+  }, [getUserAuth]);
 
   return (
     <Suspense fallback={<Loading />}>


### PR DESCRIPTION
src/App.js
Line 32:6: React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array. However, 'props' will change when any prop changes, so the preferred fix is to destructure the 'props' object outside of the useEffect call and refer to those specific props inside useEffect react-hooks/exhaustive-deps

function App({getUserAuth}) {
useEffect(() => {
getUserAuth();
}, [getUserAuth]);

Replaced to this by destructuring the props for useEffect.
